### PR TITLE
Only approve branches that have 'automerge' enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 var args struct {
@@ -26,6 +27,8 @@ type Client struct {
 	bitbucketClient *bitbucket.APIClient
 	logger          *logrus.Logger
 }
+
+const MANUAL_MERGE_MESSAGE = "**Automerge**: Disabled by config. Please merge this manually once you are satisfied."
 
 func main() {
 	logger := logrus.New()
@@ -78,6 +81,11 @@ func main() {
 				logger.Infof("skipping %d because %s != %s", v.ID, v.Author.User.Slug, args.AuthorFilter)
 				continue
 			}
+		}
+
+		if strings.Contains(v.Description, MANUAL_MERGE_MESSAGE) {
+			logger.Infof("skipping %s (id: %d) because renovate bot 'automerge' is disabled", v.Title, v.ID)
+			continue
 		}
 
 		c.logger.Infof("Auto-approving %s - %s - %s",


### PR DESCRIPTION
Currently the bot approves all PRs ignoring if the Renovate-Bot "auto merge" feature is enabled or not.

The renovate-approve-bot-bitbucket-cloud behaves differently and ignores/filters PRs that don't have the auto merge feature enabled, see https://github.com/renovatebot/renovate-approve-bot-bitbucket-cloud/blob/main/index.js#L28

I adopted this functionality in this PR.